### PR TITLE
Don't schedule a `requestAnimationFrame` if there is nothing to animate

### DIFF
--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -52,10 +52,10 @@ class JSConfetti {
 
     this.iterationIndex++
 
-    this.queueAnimationFrameIfNeeded()
+    this.queueAnimationFrameIfNeeded(currentTime)
   }
 
-  private queueAnimationFrameIfNeeded(): void {
+  private queueAnimationFrameIfNeeded(currentTime?: number): void {
     if (this.requestAnimationFrameRequested) {
       // We already have a pended animation frame, so there is no more work
       return
@@ -69,7 +69,7 @@ class JSConfetti {
     this.requestAnimationFrameRequested = true
 
     // Capture the last updated time for animation
-    this.lastUpdated = new Date().getTime()
+    this.lastUpdated = currentTime || new Date().getTime()
     requestAnimationFrame(this.loop)
   }
 

--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -13,11 +13,12 @@ class JSConfetti {
   private lastUpdated: number
 
   private iterationIndex: number
+  private requestAnimationFrameRequested: boolean
 
   public constructor(jsConfettiConfig: IJSConfettiConfig = {}) {
     this.canvas = jsConfettiConfig.canvas || createCanvas()
     this.canvasContext = <CanvasRenderingContext2D>this.canvas.getContext('2d')
-
+    this.requestAnimationFrameRequested = false
     this.shapes = []
 
     this.lastUpdated = new Date().getTime()
@@ -29,6 +30,8 @@ class JSConfetti {
   }
 
   private loop(): void {
+    this.requestAnimationFrameRequested = false
+
     fixDPR(this.canvas)
 
     const currentTime = new Date().getTime()
@@ -47,9 +50,26 @@ class JSConfetti {
       this.shapes = this.shapes.filter((shape) => shape.getIsVisibleOnCanvas(canvasHeight))
     }
 
-    this.lastUpdated = currentTime
     this.iterationIndex++
 
+    this.queueAnimationFrameIfNeeded()
+  }
+
+  private queueAnimationFrameIfNeeded(): void {
+    if (this.requestAnimationFrameRequested) {
+      // We already have a pended animation frame, so there is no more work
+      return
+    }
+
+    if (this.shapes.length < 1) {
+      // No shapes to animate, so don't queue another frame
+      return
+    }
+
+    this.requestAnimationFrameRequested = true
+
+    // Capture the last updated time for animation
+    this.lastUpdated = new Date().getTime()
     requestAnimationFrame(this.loop)
   }
 
@@ -101,6 +121,8 @@ class JSConfetti {
         canvasWidth,
       }))
     }
+
+    this.queueAnimationFrameIfNeeded()
   }
 }
 


### PR DESCRIPTION
With this change, a `requestAnimationFrame` is not scheduled unless there is active confetti to animate.

This is because when idle, the browser will continue to do work, even though there is no work to do.

However, adding confentti will restart the loop if it is not currently running. If it is, no additional frames are scheduled.