### PR TITLE
Return a promise when an confetti batch completes animating

### DIFF
--- a/site/index.tsx
+++ b/site/index.tsx
@@ -24,7 +24,6 @@ const CONFETTI_ARGS: IAddConfettiConfig[] = [
   },
 ]
 
-
 function App(): JSX.Element {
   const jsConfettiRef = useRef<JSConfetti>()
 
@@ -33,7 +32,7 @@ function App(): JSX.Element {
 
     const timeoutId = setTimeout(() => {
       if (jsConfettiRef.current) {
-        jsConfettiRef.current.addConfetti(generateRandomArrayElement(CONFETTI_ARGS))
+        jsConfettiRef.current.addConfetti(generateRandomArrayElement(CONFETTI_ARGS)).then(() => console.log("Initial batch completed"))
       }
     }, 1000)
 
@@ -42,7 +41,7 @@ function App(): JSX.Element {
 
   const onButtonClick = useCallback(() => {
     if (jsConfettiRef.current) {
-      jsConfettiRef.current.addConfetti(generateRandomArrayElement(CONFETTI_ARGS))
+      jsConfettiRef.current.addConfetti(CONFETTI_ARGS[2]).then(() => console.log("Manual batch completed"))
     }
   }, [jsConfettiRef])
 

--- a/site/index.tsx
+++ b/site/index.tsx
@@ -41,7 +41,7 @@ function App(): JSX.Element {
 
   const onButtonClick = useCallback(() => {
     if (jsConfettiRef.current) {
-      jsConfettiRef.current.addConfetti(CONFETTI_ARGS[2]).then(() => console.log("Manual batch completed"))
+      jsConfettiRef.current.addConfetti(generateRandomArrayElement(CONFETTI_ARGS)).then(() => console.log("Manual batch completed"))
     }
   }, [jsConfettiRef])
 

--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -6,42 +6,38 @@ import { IPosition, IJSConfettiConfig, IAddConfettiConfig } from './types'
 
 class ConfettiBatch {
   private promiseCompletion?: () => void
-  private promise?: Promise<void>
-  private members: ConfettiShape[]
+  private promise: Promise<void>
+  private shapes: ConfettiShape[]
 
   constructor() {
-    this.members = []
+    this.shapes = []
+    this.promise = new Promise((completionCallback) => this.promiseCompletion = completionCallback);
   }
 
   getPromise(): Promise<void> {
-    if (!this.promise) {
-      this.promise = new Promise((completionCallback) => this.promiseCompletion = completionCallback)
-    }
-
     return this.promise
   }
 
   addShapes(...shapes: ConfettiShape[]): void {
-    this.members.push(...shapes)
+    this.shapes.push(...shapes)
   }
 
   complete(): boolean {
-    if (this.members.length) {
+    if (this.shapes.length) {
       return false
     }
     
-    // If a promise was never requested, we can't complete it
     this.promiseCompletion?.()
 
     return true
   }
 
   filterShapes(height: number): void {
-    if (this.members.length < 1) {
+    if (this.shapes.length < 1) {
       return
     }
 
-    this.members = this.members.filter((shape) => shape.getIsVisibleOnCanvas(height))
+    this.shapes = this.shapes.filter((shape) => shape.getIsVisibleOnCanvas(height))
   }
 }
 
@@ -155,7 +151,7 @@ class JSConfetti {
     const confettiGroup = new ConfettiBatch()
 
     for (let i = 0; i < confettiNumber / 2; i++) {
-      const right = new ConfettiShape({
+      const confettiOnTheRight = new ConfettiShape({
         initialPosition: leftConfettiPosition, 
         direction: 'right',
         confettiRadius,
@@ -166,7 +162,7 @@ class JSConfetti {
         canvasWidth,
       })
 
-      const left = new ConfettiShape({
+      const confettiOnTheLeft = new ConfettiShape({
         initialPosition: rightConfettiPosition, 
         direction: 'left',
         confettiRadius,
@@ -177,8 +173,8 @@ class JSConfetti {
         canvasWidth,
       })
 
-      this.shapes.push(right, left)
-      confettiGroup.addShapes(right, left)
+      this.shapes.push(confettiOnTheRight, confettiOnTheLeft)
+      confettiGroup.addShapes(confettiOnTheRight, confettiOnTheLeft)
     }
 
     this.activeConfettiBatches.push(confettiGroup)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,5 +14,5 @@ interface IAddConfettiConfig {
 declare class JSConfetti {
   constructor();
 
-  addConfetti(confettiConfig?: IAddConfettiConfig): void;
+  addConfetti(confettiConfig?: IAddConfettiConfig): Promise<void>;
 }


### PR DESCRIPTION
To enable customized behaviour when a confetti burst has completed it's animation, we need some sort of notification.

With this change, when confetti is added a `Promise` is returned that will complete when all member shapes in that batch have been removed.

Also updates exposed types, and the sample page.