### PR TITLE
Correctly position confetti source when confetti added immediately af…

### DIFF
--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -62,10 +62,14 @@ class JSConfetti {
       emojiSize,
     } = normalizeConfettiConfig(confettiConfig)
 
-    const dpr = window.devicePixelRatio
-    
-    const canvasWidth = this.canvas.width / dpr
-    const canvasHeight = this.canvas.height / dpr
+    // Use the bounding rect rather tahn the canvas width / height, because
+    // .width / .height are unset until a layout pass has been completed. Upon
+    // confetti being immediately queued on a page load, this hasn't happened so
+    // the default of 300x150 will be returned, causing an improper source point
+    // for the confetti animation.
+    const canvasRect = this.canvas.getBoundingClientRect()
+    const canvasWidth = canvasRect.width
+    const canvasHeight = canvasRect.height
 
     const yPosition = canvasHeight * 5 / 7
     


### PR DESCRIPTION
…ter instantiation

With the previous usage of `canvas.width|.height`, if confetti was added immediately after the canvas was created, the position of the confetti source was incorrect. This is because no layout pass had completed, and the defaults of 300x150 for the height/width of the canvas were applied (see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement).

Switching to `getBoundingClientRect` forces a layout pass in the browser, and returns the correct sizes immediately on creation.