### PR TITLE
clean up shapes every 10 not 100 iterations

### DIFF
--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -88,7 +88,7 @@ class JSConfetti {
     const timeDelta = currentTime - this.lastUpdated
     
     const canvasHeight = this.canvas.offsetHeight
-    const cleanupInvisibleShapes = (this.iterationIndex % 100 === 0)
+    const cleanupInvisibleShapes = (this.iterationIndex % 10 === 0)
 
     this.activeConfettiBatches = this.activeConfettiBatches.filter((batch) => {
       batch.processShapes(


### PR DESCRIPTION
now that we are resolving promise when confetti batch is completed #37  (thanks to @grork), I think we should do clean-up more often in order to remove 1-2 seconds delay between shapes disappearing from the screen and the promise resolve

filtering invisible shapes is not so heavy operation compared to drawing shapes, and on the other hand, we reduce the number of `draw` operations, so I believe the hole library became a little bit more optimized

