### PR TITLE
Moving react and react-dom into devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "eslint-plugin-import": "^2.22.1",
     "fork-ts-checker-webpack-plugin": "^6.1.0",
     "html-webpack-plugin": "5.0.0-alpha.4",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "rollup": "^2.40.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.30.0",
@@ -58,9 +60,5 @@
   "keywords": [
     "confetti",
     "js-confetti"
-  ],
-  "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
-  }
+  ]
 }


### PR DESCRIPTION
Thanks for the library @loonywizard!

I have a project without `react`. And I noticed that `react` and `react-dom` appeared in my `package-lock.json` file after installing `js-confetti`. The library source code actually doesn't depend on those packages. I believe they are in the dependencies list because of the demo homepage.

So I moved them into `devDependencies`. They won't end up in end users' dependency tree this way, and the site should be working fine after this change.