### PR TITLE
Make typings work without allowSyntheticDefaultImports flag

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for js-confetti
 // TypeScript Version: 4.1.2
 
-export = JSConfetti;
+export default JSConfetti;
 
 interface IJSConfettiConfig {
   canvas?: HTMLCanvasElement,


### PR DESCRIPTION
I do not have the allowSyntheticDefaultImports hack turned on. I get the error:

```
Module '"js-confetti"' can only be default-imported using the 'allowSyntheticDefaultImports' flagts(1259)
js-confetti.d.ts(3, 3): This module is declared with using 'export =', and can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.
```

Everything works as expected after changing `export =` to `export default`. Looking at the implementation, it does use `export default`, so that seems like a correct typing.