### PR TITLE
fix: emoji font size is too small on high-resolution screens

### DIFF
--- a/src/ConfettiShape.ts
+++ b/src/ConfettiShape.ts
@@ -148,7 +148,7 @@ class ConfettiShape {
       )
       canvasContext.fill()
     } else if (emoji) {
-      canvasContext.font = `${emojiSize}px serif`
+      canvasContext.font = `${emojiSize * dpr}px serif`
 
       canvasContext.save()
       canvasContext.translate(dpr * currentPosition.x, dpr * currentPosition.y)


### PR DESCRIPTION
On my MacBookPro (DPI=2) screen, the actual size of the emoji font is half the size of screens with DPI=1. I resolved this issue by multiplying the font size by the DPI.
