### PR TITLE
Fix emojiSize not adaptable

### DIFF
--- a/src/normalizeConfettiConfig.ts
+++ b/src/normalizeConfettiConfig.ts
@@ -15,7 +15,7 @@ function normalizeConfettiConfig(confettiConfig: IAddConfettiConfig): INormalize
     confettiColors = DEFAULT_CONFETTI_COLORS,
 
     emojis = confettiConfig.emojies || [],
-    emojiSize = INITIAL_EMOJI_SIZE,
+    emojiSize = confettiConfig.emojiSize || INITIAL_EMOJI_SIZE,
   } = confettiConfig
 
   // deprecate wrong plural forms, used in early releases


### PR DESCRIPTION
fixes #64. 

With this change the usage of emojiSize is not intuitive, I suggest to either:
1. add documentation to give examples for reasonable inputs
2. scale from 0-1 and map those values on a reasonable value range
3. also we could enforce min and max values to prevent unreasonable inputs.

Happy to adapt anything if needed.