### PR TITLE
feat: implement addConfettiAtPosition first prototype

### DIFF
--- a/site/index.tsx
+++ b/site/index.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, {useCallback, useEffect, useRef} from 'react'
 
 import JSConfetti from '../src/index'
 import { generateRandomArrayElement  } from '../src/generateRandomArrayElement'
@@ -7,6 +7,7 @@ import { IAddConfettiConfig } from '../src/types'
 
 
 const CONFETTI_ARGS: IAddConfettiConfig[] = [
+  // empty object is for default values
   {},
   { confettiRadius: 12, confettiNumber: 100 },
   { emojis: ['🌈', '⚡️', '💥', '✨', '💫', '🌸'] },
@@ -26,6 +27,7 @@ const CONFETTI_ARGS: IAddConfettiConfig[] = [
 
 function App(): JSX.Element {
   const jsConfettiRef = useRef<JSConfetti>()
+  const clickMeButtonRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     jsConfettiRef.current = new JSConfetti()
@@ -45,10 +47,25 @@ function App(): JSX.Element {
     }
   }, [jsConfettiRef])
 
+  // early prototype, only to be used for testing for now in DEV mode
+  const onContainerClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (process.env.NODE_ENV !== 'production') {
+      if (event.target !== clickMeButtonRef.current) {
+        jsConfettiRef.current?.__DO_NOT_USE_THIS_IS_UNDER_DEVELOPMENT__addConfettiAtPosition({
+          ...generateRandomArrayElement(CONFETTI_ARGS),
+          __DO_NOT_USE__confettiDispatchPosition: {
+            x: event.clientX,
+            y: event.clientY
+          }
+        },)
+      }
+    }
+  }, [jsConfettiRef])
+
   return (
-    <>
-      <button className="button" onClick={onButtonClick}>Click me!</button>
-    </>
+    <div className="container" onClick={onContainerClick}>
+      <button className="button" onClick={onButtonClick} ref={clickMeButtonRef}>Click me!</button>
+    </div>
   )
 }
 

--- a/src/JSConfetti.ts
+++ b/src/JSConfetti.ts
@@ -6,8 +6,10 @@ import { IPosition, IJSConfettiConfig, IAddConfettiConfig } from './types'
 import {
   generateConfettiInitialFlightAngleFiredFromLeftSideOfTheScreen,
   generateConfettiInitialFlightAngleFiredFromRightSideOfTheScreen,
-  generateConfettiRotationAngleFiredFromLeftSideOfTheScreen, generateConfettiRotationAngleFiredFromRightSideOfTheScreen
-} from "./generateConfettiAngles";
+  generateConfettiInitialFlightAngleFiredFromSpecificPosition,
+  generateConfettiRotationAngleFiredFromLeftSideOfTheScreen,
+  generateConfettiRotationAngleFiredFromRightSideOfTheScreen
+} from "./generateConfettiAngles"
 
 class ConfettiBatch {
   private resolvePromise?: () => void
@@ -132,6 +134,45 @@ class JSConfetti {
     requestAnimationFrame(this.loop)
   }
 
+  public __DO_NOT_USE_THIS_IS_UNDER_DEVELOPMENT__addConfettiAtPosition(confettiConfig: IAddConfettiConfig = {}): Promise<void> {
+    const {
+      confettiRadius,
+      confettiNumber,
+      confettiColors,
+      emojis,
+      emojiSize,
+      __DO_NOT_USE__confettiDispatchPosition,
+    } = normalizeConfettiConfig(confettiConfig)
+
+    const {width: canvasWidth} = this.canvas.getBoundingClientRect()
+
+    const confettiGroup = new ConfettiBatch(this.canvasContext)
+
+
+    for (let i = 0; i < confettiNumber; i++) {
+      const confettiShape = new ConfettiShape({
+        initialPosition: __DO_NOT_USE__confettiDispatchPosition as IPosition,
+        confettiRadius,
+        confettiColors,
+        confettiNumber,
+        emojis,
+        emojiSize,
+        canvasWidth,
+        rotationAngle: generateConfettiRotationAngleFiredFromLeftSideOfTheScreen(),
+        initialFlightAngle: generateConfettiInitialFlightAngleFiredFromSpecificPosition(),
+        __DO_NOT_USE__shouldHideConfettiInShiftedPosition: true,
+      })
+
+      confettiGroup.addShapes(confettiShape)
+    }
+
+    this.activeConfettiBatches.push(confettiGroup)
+
+    this.queueAnimationFrameIfNeeded()
+
+    return confettiGroup.getBatchCompletePromise()
+  }
+
   public addConfetti(confettiConfig: IAddConfettiConfig = {}): Promise<void> {
     const {
       confettiRadius,
@@ -146,9 +187,7 @@ class JSConfetti {
     // confetti being immediately queued on a page load, this hasn't happened so
     // the default of 300x150 will be returned, causing an improper source point
     // for the confetti animation.
-    const canvasRect = this.canvas.getBoundingClientRect()
-    const canvasWidth = canvasRect.width
-    const canvasHeight = canvasRect.height
+    const {width: canvasWidth, height: canvasHeight} = this.canvas.getBoundingClientRect()
 
     const yPosition = canvasHeight * 5 / 7
 

--- a/src/generateConfettiAngles.ts
+++ b/src/generateConfettiAngles.ts
@@ -10,7 +10,7 @@ function convertDegreesToRadians(degreesToRadians: number) {
  * determine the angle at which confetti is being dispatched
  *
  * for confetti that are dispatched from the sides of the screen, there's a min and max angle at which they could fly
- * for confetti that are dispatched from the specific location (like mouse click), the angle ranges from -max to max
+ * for confetti that are dispatched from the specific position (like mouse click), the angle ranges from -max to max
  *
  * the angle is stored in radians, but degrees are used in constants for convenience
  *
@@ -24,6 +24,10 @@ function generateConfettiInitialFlightAngleFiredFromLeftSideOfTheScreen() {
 
 function generateConfettiInitialFlightAngleFiredFromRightSideOfTheScreen() {
   return convertDegreesToRadians(generateRandomNumber(-MIN_CONFETTI_ANGLE_IN_DEGREES, -MAX_CONFETTI_ANGLE_IN_DEGREES))
+}
+
+function generateConfettiInitialFlightAngleFiredFromSpecificPosition() {
+  return convertDegreesToRadians(generateRandomNumber(-MAX_CONFETTI_ANGLE_IN_DEGREES, MAX_CONFETTI_ANGLE_IN_DEGREES))
 }
 
 /*
@@ -41,6 +45,7 @@ function generateConfettiRotationAngleFiredFromRightSideOfTheScreen() {
 export {
   generateConfettiInitialFlightAngleFiredFromLeftSideOfTheScreen,
   generateConfettiInitialFlightAngleFiredFromRightSideOfTheScreen,
+  generateConfettiInitialFlightAngleFiredFromSpecificPosition,
 
   generateConfettiRotationAngleFiredFromLeftSideOfTheScreen,
   generateConfettiRotationAngleFiredFromRightSideOfTheScreen,

--- a/src/normalizeConfettiConfig.ts
+++ b/src/normalizeConfettiConfig.ts
@@ -16,13 +16,14 @@ function normalizeConfettiConfig(confettiConfig: IAddConfettiConfig): INormalize
 
     emojis = confettiConfig.emojies || [],
     emojiSize = INITIAL_EMOJI_SIZE,
+    __DO_NOT_USE__confettiDispatchPosition = null,
   } = confettiConfig
 
   // deprecate wrong plural forms, used in early releases
   if (confettiConfig.emojies) console.error(`emojies argument is deprecated, please use emojis instead`)
   if (confettiConfig.confettiesNumber) console.error(`confettiesNumber argument is deprecated, please use confettiNumber instead`)
 
-  return { confettiRadius, confettiNumber, confettiColors, emojis, emojiSize }
+  return { confettiRadius, confettiNumber, confettiColors, emojis, emojiSize, __DO_NOT_USE__confettiDispatchPosition }
 }
 
 export { normalizeConfettiConfig }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,13 +33,25 @@ interface IAddConfettiConfig {
   emojis?: string[],
   emojiSize?: number,
 
+
+  // if provided, confetti would be fired from specified position on the screen,
+  // otherwise they would be fired from the sides of the screen (default behaviour)
+  __DO_NOT_USE__confettiDispatchPosition?: IPosition | null,
+
   // @deprecated: wrong plural forms were used
   emojies?: string[],
   confettiesNumber?: number,
 }
 
 
-type INormalizedAddConfettiConfig = Required<Omit<IAddConfettiConfig, 'emojies' | 'confettiesNumber'>>
+type INormalizedAddConfettiConfig = {
+  confettiRadius: number,
+  confettiNumber: number,
+  confettiColors: string[],
+  emojis: string[],
+  emojiSize: number,
+  __DO_NOT_USE__confettiDispatchPosition?: IPosition | null,
+}
 
 
 export {


### PR DESCRIPTION
Implement `__DO_NOT_USE_THIS_IS_UNDER_DEVELOPMENT__addConfettiAtPosition` method in `JSConfetti` that is used for dispatching confetti from specific position on the screen (for example on mouse click).

This is an early prototype and I might change a few things, so I've marked the method and params with `__DO_NOT_USE*` prefixes.

In `ConfettiShape` I've added `isVisible` flag to control confetti visibility with offset position: when confetti is dispatched, it has random shifted position from the initial position, it is done for aesthetic purposes to create an effect that confetti takes some random time to be dispatched, we need to hide confetti until it has reached its initial position. However, I hide it only when with a flag, to keep the behaviour of "From sides of the screen" as is, confetti are still half-way visible there when they didn't reach the `dispatchPosition` and it looks good.

this would be the one step further to address following feature requests https://github.com/loonywizard/js-confetti/issues/54 and https://github.com/loonywizard/js-confetti/issues/47